### PR TITLE
place storeReturnTo after passport.authenticate in /routes/users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "passport-local": "^1.0.0",
         "passport-local-mongoose": "^8.0.0",
         "sanitize-html": "^2.11.0"
+      },
+      "engines": {
+        "node": "20.9.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/routes/users.js
+++ b/routes/users.js
@@ -15,7 +15,7 @@ router.route('/register')
 
 router.route('/login')
     .get(users.renderLogin)
-    .post(storeReturnTo,passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }), users.loginUser);
+    .post(passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }),storeReturnTo, users.loginUser);
 
 
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -15,7 +15,8 @@ router.route('/register')
 
 router.route('/login')
     .get(users.renderLogin)
-    .post(storeReturnTo,passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }),users.loginUser);
+    .post(passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }), storeReturnTo, users.loginUser);
+
 
 
 router.get('/logout',users.logoutUser);

--- a/routes/users.js
+++ b/routes/users.js
@@ -15,7 +15,7 @@ router.route('/register')
 
 router.route('/login')
     .get(users.renderLogin)
-    .post(passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }), storeReturnTo, users.loginUser);
+    .post(storeReturnTo,passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }), users.loginUser);
 
 
 


### PR DESCRIPTION
Upon reviewing the code, I noticed a potential issue in the route definitions. Specifically, in the login route, the `storeReturnTo` middleware is placed before the `passport.authenticate` middleware. This could cause an issue because `storeReturnTo` middleware might not get a chance to execute before the passport authentication middleware takes over the request. Let's reorder the middleware so that `storeReturnTo` is called after `passport.authenticate`:

```javascript
router.route('/login')
    .get(users.renderLogin)
    .post(passport.authenticate('local', { failureFlash: true, failureRedirect: '/login' }), storeReturnTo, users.loginUser);
